### PR TITLE
feat: ios 네이버 로그인 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.0",
     "passport-kakao": "^1.0.1",
+    "passport-naver-v2": "^2.0.8",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,7 +34,7 @@ export class AuthController {
   }
   @Get('kakao/redirect')
   @UseGuards(KakaoAuthGuard)
-  deprecatedKakaoRedirect(@UserRequest() accessToken): void {
+  deprecatedKakaoRedirect(@UserRequest() accessToken: AccessToken): void {
     console.log(accessToken);
   }
 
@@ -45,7 +45,7 @@ export class AuthController {
   }
   @Get('naver/redirect')
   @UseGuards(NaverAuthGuard)
-  deprecatedNaverRedirect(@UserRequest() accessToken): void {
+  deprecatedNaverRedirect(@UserRequest() accessToken: AccessToken): void {
     console.log(accessToken);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -13,7 +13,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService, private readonly configService: ConfigService) {}
 
   @Post('*/login')
-  async kakaoLogin(
+  async oauthLogin(
     @Body() loginRequest: LoginRequest,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AccessToken> {
@@ -40,7 +40,7 @@ export class AuthController {
 
   @Get('naver')
   @UseGuards(NaverAuthGuard)
-  deprecatedNaverLogin() {
+  deprecatedNaverLogin(): string {
     return 'success';
   }
   @Get('naver/redirect')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Post, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 import { Response } from 'express';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { AuthService } from './auth.service';
@@ -13,6 +14,10 @@ export class AuthController {
   constructor(private readonly authService: AuthService, private readonly configService: ConfigService) {}
 
   @Post('*/login')
+  @ApiOperation({ description: 'OAuth 로그인' })
+  @ApiBody({ description: 'OAuth AccessToken 토큰과 제공자', type: LoginRequestDto })
+  @ApiCreatedResponse({ description: '로그인/회원가입 성공' })
+  @ApiBadRequestResponse({ description: '유효하지 않은 제공자 혹은, 해당 SNS 로그인에 동의하지 않음' })
   async oauthLogin(
     @Body() loginRequest: LoginRequest,
     @Res({ passthrough: true }) res: Response,
@@ -29,22 +34,26 @@ export class AuthController {
   // 정식 배포 전까지 액세스 토큰을 원활하게 탐색하기 위해 남겨놓았습니다.
   @Get('kakao')
   @UseGuards(KakaoAuthGuard)
+  @ApiOperation({ deprecated: true, description: '카카오 계정 테스트를 위한 임시 API' })
   deprecatedKakaoLogin(): string {
     return 'success';
   }
   @Get('kakao/redirect')
   @UseGuards(KakaoAuthGuard)
+  @ApiOperation({ deprecated: true, description: '카카오 계정 테스트를 위한 임시 API - Redirect' })
   deprecatedKakaoRedirect(@UserRequest() accessToken: AccessToken): void {
     console.log(accessToken);
   }
 
   @Get('naver')
   @UseGuards(NaverAuthGuard)
+  @ApiOperation({ deprecated: true, description: '네이버 계정 테스트를 위한 임시 API' })
   deprecatedNaverLogin(): string {
     return 'success';
   }
   @Get('naver/redirect')
   @UseGuards(NaverAuthGuard)
+  @ApiOperation({ deprecated: true, description: '네이버 계정 테스트를 위한 임시 API - Redirect' })
   deprecatedNaverRedirect(@UserRequest() accessToken: AccessToken): void {
     console.log(accessToken);
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -11,9 +11,12 @@ import { KakaoAuthGuard } from './utils/guards/kakao-auth.guard';
 export class AuthController {
   constructor(private readonly authService: AuthService, private readonly configService: ConfigService) {}
 
-  @Post('kakao/login')
-  async kakaoLogin(@Body() kakaoData: LoginRequest, @Res({ passthrough: true }) res: Response): Promise<AccessToken> {
-    const { accessToken, refreshToken } = await this.authService.login(kakaoData);
+  @Post('*/login')
+  async kakaoLogin(
+    @Body() loginRequest: LoginRequest,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<AccessToken> {
+    const { accessToken, refreshToken } = await this.authService.login(loginRequest);
 
     res.cookie('refresh_token', refreshToken, {
       httpOnly: true,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,7 +4,7 @@ import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiOkResponse, ApiO
 import { Response } from 'express';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { AuthService } from './auth.service';
-import { LoginRequest } from './dto/login-request.dto';
+import { LoginRequestDto } from './dto/login-request.dto';
 import { AccessToken } from './types/token-response.interface';
 import { KakaoAuthGuard } from './utils/guards/kakao-auth.guard';
 import { NaverAuthGuard } from './utils/guards/naver-auth.guard';
@@ -19,10 +19,10 @@ export class AuthController {
   @ApiCreatedResponse({ description: '로그인/회원가입 성공' })
   @ApiBadRequestResponse({ description: '유효하지 않은 제공자 혹은, 해당 SNS 로그인에 동의하지 않음' })
   async oauthLogin(
-    @Body() loginRequest: LoginRequest,
+    @Body() loginRequestdto: LoginRequestDto,
     @Res({ passthrough: true }) res: Response,
   ): Promise<AccessToken> {
-    const { accessToken, refreshToken } = await this.authService.login(loginRequest);
+    const { accessToken, refreshToken } = await this.authService.login(loginRequestdto);
 
     res.cookie('refresh_token', refreshToken, {
       httpOnly: true,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import { AuthService } from './auth.service';
 import { LoginRequest } from './dto/login-request.dto';
 import { AccessToken } from './types/token-response.interface';
 import { KakaoAuthGuard } from './utils/guards/kakao-auth.guard';
+import { NaverAuthGuard } from './utils/guards/naver-auth.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -34,6 +35,17 @@ export class AuthController {
   @Get('kakao/redirect')
   @UseGuards(KakaoAuthGuard)
   deprecatedKakaoRedirect(@UserRequest() accessToken): void {
+    console.log(accessToken);
+  }
+
+  @Get('naver')
+  @UseGuards(NaverAuthGuard)
+  deprecatedNaverLogin() {
+    return 'success';
+  }
+  @Get('naver/redirect')
+  @UseGuards(NaverAuthGuard)
+  deprecatedNaverRedirect(@UserRequest() accessToken): void {
     console.log(accessToken);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -7,6 +7,7 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './utils/strategies/jwt.strategy';
 import { UserModule } from '../user/user.module';
+import { NaverStrategy } from './utils/strategies/naver.strategy';
 
 @Module({
   imports: [
@@ -22,6 +23,6 @@ import { UserModule } from '../user/user.module';
     UserModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, KakaoStrategy, JwtStrategy],
+  providers: [AuthService, KakaoStrategy, JwtStrategy, NaverStrategy],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -31,7 +31,6 @@ export class AuthService {
       default: {
         throw new BadRequestException({
           message: '유효하지 않는 OAuth 요청입니다.',
-          statusCode: HttpStatus.BAD_REQUEST,
         });
       }
     }
@@ -54,7 +53,6 @@ export class AuthService {
     if (!user) {
       throw new BadRequestException({
         message: '카카오 로그인에 실패했습니다',
-        statusCode: HttpStatus.BAD_REQUEST,
       });
     }
 
@@ -87,7 +85,6 @@ export class AuthService {
     if (!user) {
       throw new BadRequestException({
         message: '네이버 로그인에 실패했습니다',
-        statusCode: HttpStatus.BAD_REQUEST,
       });
     }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -4,7 +4,7 @@ import { AuthProvider } from '../entities/types/auth-provider.enum';
 import { UserRepository } from '../user/repository/user.repository';
 import { JwtSubjectType } from './types/jwtSubjectType';
 import { ConfigService } from '@nestjs/config';
-import { LoginRequest } from './dto/login-request.dto';
+import { LoginRequestDto } from './dto/login-request.dto';
 import axios from 'axios';
 import { TokenResponse } from './types/token-response.interface';
 import { User } from '../entities/user.entity';
@@ -17,7 +17,7 @@ export class AuthService {
     private readonly userRepository: UserRepository,
   ) {}
 
-  async login(data: LoginRequest): Promise<TokenResponse> {
+  async login(data: LoginRequestDto): Promise<TokenResponse> {
     let userId: number;
     switch (data.vendor) {
       case 'kakao': {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -30,7 +30,7 @@ export class AuthService {
       }
       default: {
         throw new BadRequestException({
-          message: '지원하지 않는 OAuth 요청입니다.',
+          message: '유효하지 않는 OAuth 요청입니다.',
           statusCode: HttpStatus.BAD_REQUEST,
         });
       }

--- a/src/auth/dto/login-request.dto.ts
+++ b/src/auth/dto/login-request.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class LoginRequest {
+export class LoginRequestDto {
   @IsString()
   @IsNotEmpty()
   accessToken!: string;

--- a/src/auth/utils/guards/naver-auth.guard.ts
+++ b/src/auth/utils/guards/naver-auth.guard.ts
@@ -1,0 +1,5 @@
+import { Injectable } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class NaverAuthGuard extends AuthGuard('naver') {}

--- a/src/auth/utils/strategies/kakao.strategy.ts
+++ b/src/auth/utils/strategies/kakao.strategy.ts
@@ -2,12 +2,11 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-kakao';
-import { AuthService } from '../../auth.service';
 import { KakaoProfile } from '../../types/kakao-profile.interface';
 
 @Injectable()
 export class KakaoStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly configService: ConfigService, private readonly authService: AuthService) {
+  constructor(private readonly configService: ConfigService) {
     super({
       clientID: configService.get<string>('KAKAO_CLIENT_ID'),
       clientSecret: configService.get<string>('KAKAO_SECRET'),

--- a/src/auth/utils/strategies/naver.strategy.ts
+++ b/src/auth/utils/strategies/naver.strategy.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { Strategy } from 'passport-naver-v2';
+
+@Injectable()
+export class NaverStrategy extends PassportStrategy(Strategy) {
+  constructor(private readonly configService: ConfigService) {
+    super({
+      clientID: configService.get<string>('NAVER_CLIENT_ID'),
+      clientSecret: configService.get<string>('NAVER_SECRET'),
+      callbackURL: configService.get<string>('NAVER_CALLBACK_URL'),
+    });
+  }
+
+  async validate(_accessToken: string, _refreshToken: string, profile: any, done: CallableFunction): Promise<void> {
+    done(null, _accessToken);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,6 +1656,11 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+base64url@3.x.x:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/base64url/-/base64url-3.0.1.tgz#6399d572e2bc3f90a9a8b22d5dbb0a32d33f788d"
+  integrity sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
@@ -4181,6 +4186,24 @@ passport-kakao@^1.0.1:
     passport-oauth2 "~1.1.2"
     pkginfo "~0.3.0"
 
+passport-naver-v2@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/passport-naver-v2/-/passport-naver-v2-2.0.8.tgz#db552aec4aa843bef7c18a10e871dc4431c1f918"
+  integrity sha512-CA0u+aA4K4Zf5e3dSd47agOS69ULOdBGei7CZY2BN1cEbLnhnc6OalFPvnXLuEKT8I4IuGwvh3EBZCST2FoI+A==
+  dependencies:
+    passport-oauth2 "^1.5.0"
+
+passport-oauth2@^1.5.0:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.6.1.tgz#c5aee8f849ce8bd436c7f81d904a3cd1666f181b"
+  integrity sha512-ZbV43Hq9d/SBSYQ22GOiglFsjsD1YY/qdiptA+8ej+9C1dL1TVB+mBE5kDH/D4AJo50+2i8f4bx0vg4/yDDZCQ==
+  dependencies:
+    base64url "3.x.x"
+    oauth "0.9.x"
+    passport-strategy "1.x.x"
+    uid2 "0.0.x"
+    utils-merge "1.x.x"
+
 passport-oauth2@~1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.1.2.tgz"
@@ -5156,7 +5179,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-utils-merge@1.0.1, utils-merge@^1.0.1:
+utils-merge@1.0.1, utils-merge@1.x.x, utils-merge@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==


### PR DESCRIPTION
# 작업한 내용

네이버 로그인 기능도 추가했습니다.

# 향후 작업할 내용

1. 구글 로그인 구현 -> 미리 작성해놓아서 일부분 수정만 하고 바로 PR 날리겠습니다.
2. 로그인 api를 하나로 통합할까 합니다.
```ts
// 네이버 서비스 부분
    const naverResponse = user.data.response;
    const snsId = naverResponse.id;
    const existedUser = await this.userRepository.findOne({ where: { snsId } });

    if (!existedUser) {
      const { nickname, profile_image: avatarUrl, email } = naverResponse;
      const { id } = await this.userRepository.save({
        snsId,
        email,
        nickname,
        avatarUrl,
        provider: AuthProvider.NAVER,
      });
      return id;
    }

    return existedUser.id;
```
```ts
    if (!existedUser) {
      const { nickname, profile_image: avatarUrl } = kakaoData.properties;
      const kakaoAccount = kakaoData.kakao_account;
      const email = kakaoAccount.has_email && !kakaoAccount.email_needs_agreement ? kakaoAccount.email : null;
      const { id } = await this.userRepository.save({
        snsId,
        email,
        nickname,
        avatarUrl,
        provider: AuthProvider.KAKAO,
      });
      return id;
    }

    return existedUser.id;
```

사실 둘이 데이터 정제를 제외하고는 동일한 과정이라서 컨트롤러처럼 통합해도 좋아 보였습니다.