### PR TITLE
feat: 전체 태그 조회 api 추가

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,10 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 
 @Controller()
 export class AppController {
   @Get('/')
+  @ApiExcludeEndpoint()
   @ApiTags('health check')
   healthCheck(): string {
     return 'ok';

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Post, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiOperation } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiBody, ApiCreatedResponse, ApiExcludeEndpoint, ApiOperation } from '@nestjs/swagger';
 import { Response } from 'express';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { AuthService } from './auth.service';
@@ -78,5 +78,17 @@ export class AuthController {
   @ApiOperation({ deprecated: true, description: '구글 계정 테스트를 위한 임시 API - Redirect' })
   deprecatedGoogleRedirect(@UserRequest() accessToken: AccessToken): void {
     console.log(accessToken);
+  }
+
+  @Get('testingapi')
+  @ApiExcludeEndpoint()
+  test(@Res({ passthrough: true }) res: Response) {
+    const accessToken = this.authService.generateAccessToken(1);
+    const refreshToken = this.authService.generateRefreshToken(1);
+    res.cookie('refresh_token', refreshToken, {
+      httpOnly: true,
+      maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
+    });
+    return { accessToken };
   }
 }

--- a/src/auth/utils/strategies/jwt.strategy.ts
+++ b/src/auth/utils/strategies/jwt.strategy.ts
@@ -10,11 +10,7 @@ import { jwtPayload } from '../../dto/jwt-payload.dto';
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(private readonly configService: ConfigService, private readonly authService: AuthService) {
     super({
-      jwtFromRequest: ExtractJwt.fromExtractors([
-        (request) => {
-          return request?.cookies?.Authorization;
-        },
-      ]),
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExipration: false,
       secretOrKey: configService.get<string>('JWT_ACCESS_TOKEN_SECRET'),
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,14 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.use(cookieParser());
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
   app.enableCors();
   const config = new DocumentBuilder()
     .setTitle('Ticlemoa Api Server')

--- a/src/tag/dto/pagination/pagination-request.dto.ts
+++ b/src/tag/dto/pagination/pagination-request.dto.ts
@@ -1,0 +1,16 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, Min } from 'class-validator';
+
+export class PaginationRequestDto {
+  @Type(() => Number)
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  page?: number = 1;
+
+  @Type(() => Number)
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  take?: number = 10;
+}

--- a/src/tag/dto/pagination/pagination-request.dto.ts
+++ b/src/tag/dto/pagination/pagination-request.dto.ts
@@ -1,16 +1,13 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
 import { IsNumber, IsOptional, Min } from 'class-validator';
 
 export class PaginationRequestDto {
-  @Type(() => Number)
   @IsOptional()
   @IsNumber()
   @Min(1)
   @ApiPropertyOptional({ description: '페이지네이션 페이지' })
   page?: number;
 
-  @Type(() => Number)
   @IsOptional()
   @IsNumber()
   @Min(1)

--- a/src/tag/dto/pagination/pagination-request.dto.ts
+++ b/src/tag/dto/pagination/pagination-request.dto.ts
@@ -6,14 +6,14 @@ export class PaginationRequestDto {
   @Type(() => Number)
   @IsOptional()
   @IsNumber()
-  @Min(0)
+  @Min(1)
   @ApiPropertyOptional({ description: '페이지네이션 페이지' })
-  page?: number = 1;
+  page?: number;
 
   @Type(() => Number)
   @IsOptional()
   @IsNumber()
   @Min(1)
   @ApiPropertyOptional({ description: '페이지네이션 개수' })
-  take?: number = 10;
+  take?: number;
 }

--- a/src/tag/dto/pagination/pagination-request.dto.ts
+++ b/src/tag/dto/pagination/pagination-request.dto.ts
@@ -1,3 +1,4 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { IsNumber, IsOptional, Min } from 'class-validator';
 
@@ -6,11 +7,13 @@ export class PaginationRequestDto {
   @IsOptional()
   @IsNumber()
   @Min(0)
+  @ApiPropertyOptional({ description: '페이지네이션 페이지' })
   page?: number = 1;
 
   @Type(() => Number)
   @IsOptional()
   @IsNumber()
   @Min(1)
+  @ApiPropertyOptional({ description: '페이지네이션 개수' })
   take?: number = 10;
 }

--- a/src/tag/dto/response/response-tag.dto.ts
+++ b/src/tag/dto/response/response-tag.dto.ts
@@ -25,6 +25,4 @@ export class OneTagResponseDto {
   }
 }
 
-export class ManyTagsResponseDto {
-  tags: OneTagResponseDto[];
-}
+export type ManyTagsResponseDto = OneTagResponseDto[];

--- a/src/tag/dto/response/response-tag.dto.ts
+++ b/src/tag/dto/response/response-tag.dto.ts
@@ -25,4 +25,18 @@ export class OneTagResponseDto {
   }
 }
 
-export type ManyTagsResponseDto = OneTagResponseDto[];
+export class ManyTagsResponseDto {
+  @ApiProperty({
+    description: '태그 오브젝트 리스트',
+    example: [
+      {
+        id: 18,
+        userId: 14,
+        tagName: '디프만 짱',
+        createdAt: '2022-12-17T17:18:19.014Z',
+        updatedAt: '2022-12-17T17:18:19.014Z',
+      },
+    ],
+  })
+  tags: OneTagResponseDto[];
+}

--- a/src/tag/dto/tag.mapper.ts
+++ b/src/tag/dto/tag.mapper.ts
@@ -14,6 +14,6 @@ export class TagDtoMapper {
   }
 
   static toResponseDtoList({ tags, user }: { tags: Tag[]; user: User }): ManyTagsResponseDto {
-    return tags.map((tag) => this.toResponseDto({ tag, user }));
+    return { tags: tags.map((tag) => this.toResponseDto({ tag, user })) };
   }
 }

--- a/src/tag/dto/tag.mapper.ts
+++ b/src/tag/dto/tag.mapper.ts
@@ -1,6 +1,6 @@
 import { Tag } from '../../entities/tag.entity';
 import { User } from '../../entities/user.entity';
-import { OneTagResponseDto } from './response/response-tag.dto';
+import { ManyTagsResponseDto, OneTagResponseDto } from './response/response-tag.dto';
 
 export class TagDtoMapper {
   static toResponseDto({ tag, user }: { tag: Tag; user: User }): OneTagResponseDto {
@@ -13,7 +13,7 @@ export class TagDtoMapper {
     });
   }
 
-  static toResponseDtoList({ tags, user }: { tags: Tag[]; user: User }): OneTagResponseDto[] {
+  static toResponseDtoList({ tags, user }: { tags: Tag[]; user: User }): ManyTagsResponseDto {
     return tags.map((tag) => this.toResponseDto({ tag, user }));
   }
 }

--- a/src/tag/repository/tag.repository.ts
+++ b/src/tag/repository/tag.repository.ts
@@ -1,8 +1,9 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Tag } from '../../entities/tag.entity';
 import { CreateTagRequestDto } from '../dto/request/request-tag.dto';
+import { OneTagResponseDto } from '../dto/response/response-tag.dto';
 
 @Injectable()
 export class TagRepository extends Repository<Tag> {
@@ -20,4 +21,8 @@ export class TagRepository extends Repository<Tag> {
     }
     return await this.save({ userId, tagName });
   }
+
+  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<OneTagResponseDto[]> {
+    const { page, take } = paginationRequestDto;
+    return this.find({ where: { userId }, take, skip: take * (page - 1), order: { createdAt: 'desc' } });
 }

--- a/src/tag/repository/tag.repository.ts
+++ b/src/tag/repository/tag.repository.ts
@@ -11,7 +11,7 @@ export class TagRepository extends Repository<Tag> {
     super(tagRepository.target, tagRepository.manager, tagRepository.queryRunner);
   }
 
-  async createOneTag(userId: number, createTagRequestDto: CreateTagRequestDto): Promise<Tag> {
+  async createOne(userId: number, createTagRequestDto: CreateTagRequestDto): Promise<Tag> {
     const { tagName } = createTagRequestDto;
     const existedTag: Tag = await this.findOne({ where: { tagName, userId } });
     if (existedTag) {
@@ -22,8 +22,12 @@ export class TagRepository extends Repository<Tag> {
     return await this.save({ userId, tagName });
   }
 
-  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<Tag[]> {
-    const { page = 1, take = 10 } = paginationRequestDto;
-    return this.find({ where: { userId }, take, skip: take * (page - 1), order: { createdAt: 'DESC' } });
+  async findAll(userId: number, paginationRequestDto: PaginationRequestDto): Promise<Tag[]> {
+    const { page, take } = paginationRequestDto;
+    const query = this.createQueryBuilder('tag').where('tag.user_id = :userId', { userId });
+    if (page && take) {
+      query.take(take).skip(take * (page - 1));
+    }
+    return query.getMany();
   }
 }

--- a/src/tag/repository/tag.repository.ts
+++ b/src/tag/repository/tag.repository.ts
@@ -2,8 +2,8 @@ import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Tag } from '../../entities/tag.entity';
+import { PaginationRequestDto } from '../dto/pagination/pagination-request.dto';
 import { CreateTagRequestDto } from '../dto/request/request-tag.dto';
-import { OneTagResponseDto } from '../dto/response/response-tag.dto';
 
 @Injectable()
 export class TagRepository extends Repository<Tag> {
@@ -22,7 +22,8 @@ export class TagRepository extends Repository<Tag> {
     return await this.save({ userId, tagName });
   }
 
-  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<OneTagResponseDto[]> {
-    const { page, take } = paginationRequestDto;
-    return this.find({ where: { userId }, take, skip: take * (page - 1), order: { createdAt: 'desc' } });
+  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<Tag[]> {
+    const { page = 1, take = 10 } = paginationRequestDto;
+    return this.find({ where: { userId }, take, skip: take * (page - 1), order: { createdAt: 'DESC' } });
+  }
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -1,11 +1,12 @@
-import { Body, Controller, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
 import { ApiBadRequestResponse, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/utils/guards/jwt-auth.guard';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { User } from '../entities/user.entity';
+import { TagDtoMapper } from './dto/tag.mapper';
+import { PaginationRequestDto } from './dto/pagination-request.dto';
 import { CreateTagRequestDto } from './dto/request/request-tag.dto';
 import { OneTagResponseDto } from './dto/response/response-tag.dto';
-import { TagDtoMapper } from './dto/tag.mapper';
 import { TagService } from './tag.service';
 
 @ApiTags('tag')
@@ -25,5 +26,14 @@ export class TagController {
     const tag = await this.tagService.createTag(user.id, createTagRequest);
 
     return TagDtoMapper.toResponseDto({ tag, user });
+  }
+
+  @Get()
+  @UseGuards(JwtAuthGuard)
+  async findAllTags(
+    @UserRequest() user: User,
+    @Query() { ...paginationRequestDto }: PaginationRequestDto,
+  ): Promise<OneTagResponseDto[]> {
+    return await this.tagService.findAllTags(user.id, paginationRequestDto);
   }
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -1,12 +1,12 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
-import { ApiBadRequestResponse, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiBadRequestResponse, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../auth/utils/guards/jwt-auth.guard';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { User } from '../entities/user.entity';
 import { TagDtoMapper } from './dto/tag.mapper';
 import { PaginationRequestDto } from './dto/pagination/pagination-request.dto';
 import { CreateTagRequestDto } from './dto/request/request-tag.dto';
-import { OneTagResponseDto } from './dto/response/response-tag.dto';
+import { ManyTagsResponseDto, OneTagResponseDto } from './dto/response/response-tag.dto';
 import { TagService } from './tag.service';
 
 @ApiTags('tag')
@@ -30,10 +30,27 @@ export class TagController {
 
   @Get()
   @UseGuards(JwtAuthGuard)
+  @ApiOperation({ description: '모든 태그를 조회합니다. 쿼리에 값을 넣어 페이지네이션도 할 수 있습니다.' })
+  @ApiOkResponse({
+    schema: {
+      type: 'array',
+      items: {
+        type: 'object',
+        example: {
+          userId: 1,
+          id: 18,
+          tagName: '디프만 최고18',
+          createdAt: '2022-12-17T17:18:19.014Z',
+          updatedAt: '2022-12-17T17:18:19.014Z',
+        },
+      },
+    },
+    description: '태그 조회 성공하여 객체 배열을 반환합니다.',
+  })
   async findAllTags(
     @UserRequest() user: User,
     @Query() { ...paginationRequestDto }: PaginationRequestDto,
-  ): Promise<OneTagResponseDto[]> {
+  ): Promise<ManyTagsResponseDto> {
     const tags = await this.tagService.findAllTags(user.id, paginationRequestDto);
 
     return TagDtoMapper.toResponseDtoList({ tags, user });

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -4,7 +4,7 @@ import { JwtAuthGuard } from '../auth/utils/guards/jwt-auth.guard';
 import { UserRequest } from '../common/decorators/user-request.decorator';
 import { User } from '../entities/user.entity';
 import { TagDtoMapper } from './dto/tag.mapper';
-import { PaginationRequestDto } from './dto/pagination-request.dto';
+import { PaginationRequestDto } from './dto/pagination/pagination-request.dto';
 import { CreateTagRequestDto } from './dto/request/request-tag.dto';
 import { OneTagResponseDto } from './dto/response/response-tag.dto';
 import { TagService } from './tag.service';
@@ -34,6 +34,8 @@ export class TagController {
     @UserRequest() user: User,
     @Query() { ...paginationRequestDto }: PaginationRequestDto,
   ): Promise<OneTagResponseDto[]> {
-    return await this.tagService.findAllTags(user.id, paginationRequestDto);
+    const tags = await this.tagService.findAllTags(user.id, paginationRequestDto);
+
+    return TagDtoMapper.toResponseDtoList({ tags, user });
   }
 }

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -31,22 +31,7 @@ export class TagController {
   @Get()
   @UseGuards(JwtAuthGuard)
   @ApiOperation({ description: '모든 태그를 조회합니다. 쿼리에 값을 넣어 페이지네이션도 할 수 있습니다.' })
-  @ApiOkResponse({
-    schema: {
-      type: 'array',
-      items: {
-        type: 'object',
-        example: {
-          userId: 1,
-          id: 18,
-          tagName: '디프만 최고18',
-          createdAt: '2022-12-17T17:18:19.014Z',
-          updatedAt: '2022-12-17T17:18:19.014Z',
-        },
-      },
-    },
-    description: '태그 조회 성공하여 객체 배열을 반환합니다.',
-  })
+  @ApiOkResponse({ description: '조회에 성공하여 태그 오브젝트를 배열로 반환합니다.', type: ManyTagsResponseDto })
   async findAllTags(
     @UserRequest() user: User,
     @Query() { ...paginationRequestDto }: PaginationRequestDto,

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Tag } from '../entities/tag.entity';
+import { PaginationRequestDto } from './dto/pagination/pagination-request.dto';
 import { CreateTagRequestDto } from './dto/request/request-tag.dto';
-import { OneTagResponseDto } from './dto/response/response-tag.dto';
 import { TagRepository } from './repository/tag.repository';
 
 @Injectable()
@@ -12,7 +12,7 @@ export class TagService {
     return await this.tagRepository.createOneTag(userId, createTagRequestDto);
   }
 
-  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<OneTagResponseDto[]> {
+  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<Tag[]> {
     return await this.tagRepository.findAllTags(userId, paginationRequestDto);
   }
 }

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { Tag } from '../entities/tag.entity';
 import { CreateTagRequestDto } from './dto/request/request-tag.dto';
+import { OneTagResponseDto } from './dto/response/response-tag.dto';
 import { TagRepository } from './repository/tag.repository';
 
 @Injectable()
@@ -9,5 +10,9 @@ export class TagService {
 
   async createTag(userId: number, createTagRequestDto: CreateTagRequestDto): Promise<Tag> {
     return await this.tagRepository.createOneTag(userId, createTagRequestDto);
+  }
+
+  async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<OneTagResponseDto[]> {
+    return await this.tagRepository.findAllTags(userId, paginationRequestDto);
   }
 }

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -9,10 +9,10 @@ export class TagService {
   constructor(private readonly tagRepository: TagRepository) {}
 
   async createTag(userId: number, createTagRequestDto: CreateTagRequestDto): Promise<Tag> {
-    return await this.tagRepository.createOneTag(userId, createTagRequestDto);
+    return await this.tagRepository.createOne(userId, createTagRequestDto);
   }
 
   async findAllTags(userId: number, paginationRequestDto: PaginationRequestDto): Promise<Tag[]> {
-    return await this.tagRepository.findAllTags(userId, paginationRequestDto);
+    return await this.tagRepository.findAll(userId, paginationRequestDto);
   }
 }


### PR DESCRIPTION
# 작업한 내용

전체 태그 조회 api
태그 리소스 응답 DTO 생성
태그 리소스 응답 데이터 매퍼 생성

## 작업 내용 사진

### postman 테스트

<img width="846" alt="image" src="https://user-images.githubusercontent.com/83271772/208247743-fa829fcf-7ad1-4aa9-bfaa-f942dcf44e3f.png">

### api swagger

<img width="951" alt="image" src="https://user-images.githubusercontent.com/83271772/208247789-d1331ebc-c266-4434-867e-1f34fedbb341.png">

<img width="921" alt="image" src="https://user-images.githubusercontent.com/83271772/208247809-4f63634c-edaf-48a8-9065-a75d53f60fd0.png">

# 기타

- ApiPaginationResponse: pagination이 여러 군데에 쓰이니까 따로 ApiResponse 커스텀하여 만드는 것도 좋아보였습니다.
- 요즘 몸이 많이 피곤해서 작업이 느렸네요