### PR TITLE
feat: access token 재발급 기능 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   ApiExcludeEndpoint,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 import { UserRequest } from '../common/decorators/user-request.decorator';
@@ -113,11 +114,14 @@ export class AuthController {
 
   @Post('refresh')
   @Auth()
+  @ApiCreatedResponse({ description: 'access token 재발급 성공', type: LoginResponseDto })
+  @ApiUnauthorizedResponse({ description: '유효하지 않은 refresh token으로 access token 재발급에 실패했습니다.' })
+  @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
   async refresh(
     @UserRequest() { userId }: UserPayload,
     @Req() req: Request,
     @Res({ passthrough: true }) res: Response,
-  ) {
+  ): Promise<LoginResponseDto> {
     const prevRefreshToken = req.cookies['refresh_token'];
     const { accessToken, refreshToken } = await this.authService.rotateRefreshToken(userId, prevRefreshToken);
     res.cookie('refresh_token', refreshToken, {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -189,19 +189,15 @@ export class AuthService {
   }
 
   async checkRefreshToken(refreshToken: string): Promise<void> {
-    try {
-      const payload: JwtPayload = await this.jwtService.verifyAsync(refreshToken, {
-        secret: this.configService.get('JWT_REFRESH_TOKEN_SECRET'),
-      });
-      const { refreshToken: userRefreshToken } = await this.userRepository.findOne({
-        where: { id: payload.id },
-        select: { refreshToken: true },
-      });
-      if (refreshToken !== userRefreshToken) {
-        throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-      }
-    } catch {
-      throw new BadRequestException('유효하지 않은 요청입니다.');
+    const payload: JwtPayload = await this.jwtService.verifyAsync(refreshToken, {
+      secret: this.configService.get('JWT_REFRESH_TOKEN_SECRET'),
+    });
+    const { refreshToken: userRefreshToken } = await this.userRepository.findOne({
+      where: { id: payload.id },
+      select: { refreshToken: true },
+    });
+    if (refreshToken !== userRefreshToken) {
+      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
     }
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -172,7 +172,7 @@ export class AuthService {
     );
   }
 
-  setCurrentRefreshToken(userId: number, refreshToken: string) {
+  setCurrentRefreshToken(userId: number, refreshToken: string): void {
     this.userRepository.update(userId, { refreshToken: refreshToken });
   }
 
@@ -188,7 +188,7 @@ export class AuthService {
     }
   }
 
-  async checkRefreshToken(refreshToken: string) {
+  async checkRefreshToken(refreshToken: string): Promise<void> {
     try {
       const payload: JwtPayload = await this.jwtService.verifyAsync(refreshToken, {
         secret: this.configService.get('JWT_REFRESH_TOKEN_SECRET'),
@@ -200,8 +200,8 @@ export class AuthService {
       if (refreshToken !== userRefreshToken) {
         throw new UnauthorizedException('유효하지 않은 토큰입니다.');
       }
-    } catch (e) {
-      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+    } catch {
+      throw new BadRequestException('유효하지 않은 요청입니다.');
     }
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -197,7 +197,7 @@ export class AuthService {
       select: { refreshToken: true },
     });
     if (refreshToken !== userRefreshToken) {
-      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+      throw new UnauthorizedException();
     }
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AuthProvider } from '../entities/types/auth-provider.enum';
 import { UserRepository } from '../user/repository/user.repository';
@@ -8,6 +8,7 @@ import { LoginRequestDto } from './dto/login-request.dto';
 import axios from 'axios';
 import { TokenResponse } from './types/token-response.interface';
 import { User } from '../entities/user.entity';
+import { JwtPayload } from './types/jwt-payload.interface';
 
 @Injectable()
 export class AuthService {
@@ -47,6 +48,8 @@ export class AuthService {
 
     const accessToken = this.generateAccessToken(userId);
     const refreshToken = this.generateRefreshToken(userId);
+
+    this.setCurrentRefreshToken(userId, refreshToken);
 
     return { accessToken, refreshToken, userId };
   }
@@ -167,5 +170,38 @@ export class AuthService {
         expiresIn: `${this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME')}s`,
       },
     );
+  }
+
+  setCurrentRefreshToken(userId: number, refreshToken: string) {
+    this.userRepository.update(userId, { refreshToken: refreshToken });
+  }
+
+  async rotateRefreshToken(userId: number, prevRefreshToken: string): Promise<TokenResponse> {
+    try {
+      await this.checkRefreshToken(prevRefreshToken);
+      const accessToken = this.generateAccessToken(userId);
+      const refreshToken = this.generateRefreshToken(userId);
+      this.setCurrentRefreshToken(userId, refreshToken);
+      return { accessToken, refreshToken, userId };
+    } catch {
+      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+    }
+  }
+
+  async checkRefreshToken(refreshToken: string) {
+    try {
+      const payload: JwtPayload = await this.jwtService.verifyAsync(refreshToken, {
+        secret: this.configService.get('JWT_REFRESH_TOKEN_SECRET'),
+      });
+      const { refreshToken: userRefreshToken } = await this.userRepository.findOne({
+        where: { id: payload.id },
+        select: { refreshToken: true },
+      });
+      if (refreshToken !== userRefreshToken) {
+        throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+      }
+    } catch (e) {
+      throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+    }
   }
 }

--- a/src/auth/types/jwt-payload.interface.ts
+++ b/src/auth/types/jwt-payload.interface.ts
@@ -1,8 +1,5 @@
-import { AuthProvider } from '../../entities/types/auth-provider.enum';
-
 export interface JwtPayload {
   id: number;
-  provider: AuthProvider;
 }
 
 export interface UserPayload {

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -5,6 +5,7 @@ import { Article } from './article.entity';
 import { Tag } from './tag.entity';
 import { Report } from './report.entity';
 import { Blacklist } from './blacklist.entity';
+import { Exclude } from 'class-transformer';
 
 @Entity()
 export class User extends Common {
@@ -23,6 +24,10 @@ export class User extends Common {
 
   @Column({ type: 'enum', enum: AuthProvider })
   provider!: AuthProvider;
+
+  @Exclude()
+  @Column({ type: 'varchar', length: 300, nullable: true })
+  refreshToken?: string;
 
   @OneToMany(() => Article, (article) => article.user)
   articles: Article[];

--- a/src/user/repository/user.repository.ts
+++ b/src/user/repository/user.repository.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { User } from '../../entities/user.entity';
 
 @Injectable()
 export class UserRepository extends Repository<User> {
-  constructor(@InjectRepository(User) private readonly userRepository: Repository<User>) {
-    super(userRepository.target, userRepository.manager, userRepository.queryRunner);
+  constructor(private readonly dataSource: DataSource) {
+    super(User, dataSource.createEntityManager(), dataSource.createQueryRunner());
   }
 }


### PR DESCRIPTION
# 작업한 내용

쿠키에 있는 refresh_token을 이용해서 액세스 토큰이 만료됐을 시 access token을 발급해줍니다.

이때, refresh token의 생명주기를 짧게 할 수 있도록 RTR 방식을 참고해 구현했습니다 ⬅️ 시온님 짱

반환할 때는 로그인과 마찬가지로 `access_token, userId` 를 반환합니다.
test api에서 access token을 발급할 때도 동일하게 refresh 토큰을 저장할 수 있도록 내용을 추가해서 편하게 사용하면 됩니다.

refresh 토큰을 유저 테이블에도 같이 저장하여, 해당 토큰이 유저의 토큰이 맞는지 검증하는 과정을 거치도록 했습니다.

# 적용 사진

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/83271772/210161741-8537ca04-992c-4a5c-acea-4ac2b07e015d.png">

<img width="991" alt="image" src="https://user-images.githubusercontent.com/83271772/210161744-cd5d7dd1-f61d-4d2e-8c3e-3aa1720a614d.png">

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/83271772/210161763-6d53c234-6218-4d1c-87f0-34a70b6c9f9c.png">
