### PR TITLE
feat: 로그아웃, 회원탈퇴 기능 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -114,6 +114,9 @@ export class AuthController {
 
   @Post('refresh')
   @Auth()
+  @ApiOperation({
+    description: 'refesh 토큰을 사용하여 access 토큰을 재발급합니다. RTR로 refresh 토큰도 재발급합니다,',
+  })
   @ApiCreatedResponse({ description: 'access token 재발급 성공', type: LoginResponseDto })
   @ApiUnauthorizedResponse({ description: '유효하지 않은 refresh token으로 access token 재발급에 실패했습니다.' })
   @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
@@ -130,8 +133,12 @@ export class AuthController {
     });
     return { accessToken, userId };
   }
+
   @Post('logout')
   @Auth()
+  @ApiOperation({ description: 'refresh_token 쿠키를 삭제하고, 유저 테이블에 있는 refresh 토큰을 null로 수정합니다.' })
+  @ApiNoContentResponse({ description: '로그아웃에 성공했습니다.' })
+  @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
   async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
     await this.authService.deleteRefreshToken(userId);
     res.clearCookie('refresh_token', {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -20,6 +20,7 @@ import { KakaoAuthGuard } from './utils/guards/kakao-auth.guard';
 import { NaverAuthGuard } from './utils/guards/naver-auth.guard';
 import { UserPayload } from './types/jwt-payload.interface';
 import { Auth } from './decorator/auth.decorator';
+import { WithdrawRequestDto } from './dto/withdraw-request.dto';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -141,6 +142,20 @@ export class AuthController {
   @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
   async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
     await this.authService.deleteRefreshToken(userId);
+    res.clearCookie('refresh_token', {
+      httpOnly: true,
+      maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
+    });
+  }
+
+  @Post('withdraw')
+  @Auth()
+  async withdraw(
+    @Body() withdrawRequestDto: WithdrawRequestDto,
+    @UserRequest() { userId }: UserPayload,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    await this.authService.withdraw(userId, withdrawRequestDto.accessToken);
     res.clearCookie('refresh_token', {
       httpOnly: true,
       maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Post, Req, Res, UseGuards } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
   ApiBadRequestResponse,
@@ -137,6 +137,7 @@ export class AuthController {
   }
 
   @Post('logout')
+  @HttpCode(204)
   @Auth()
   @ApiOperation({ description: 'refresh_token 쿠키를 삭제하고, 유저 테이블에 있는 refresh 토큰을 null로 수정합니다.' })
   @ApiNoContentResponse({ description: '로그아웃에 성공했습니다.' })
@@ -147,6 +148,7 @@ export class AuthController {
   }
 
   @Post('withdraw')
+  @HttpCode(204)
   @Auth()
   @ApiBody({
     description: 'OAuth 액세스 토큰',

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   ApiBody,
   ApiCreatedResponse,
   ApiExcludeEndpoint,
+  ApiNoContentResponse,
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
@@ -150,6 +151,9 @@ export class AuthController {
 
   @Post('withdraw')
   @Auth()
+  @ApiOperation({ description: '회원탈퇴' })
+  @ApiNoContentResponse({ description: '회원탈퇴에 성공했습니다.' })
+  @ApiBadRequestResponse({ description: '유효하지 않은 OAuth 요청입니다.' })
   async withdraw(
     @Body() withdrawRequestDto: WithdrawRequestDto,
     @UserRequest() { userId }: UserPayload,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -130,4 +130,13 @@ export class AuthController {
     });
     return { accessToken, userId };
   }
+  @Post('logout')
+  @Auth()
+  async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
+    await this.authService.deleteRefreshToken(userId);
+    res.clearCookie('refresh_token', {
+      httpOnly: true,
+      maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
+    });
+  }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,7 +34,7 @@ export class AuthController {
     description: 'OAuth 액세스 토큰(AccessToken) 및 제공자(vendor)',
     type: LoginRequestDto,
     examples: {
-      loginRequestDto: { value: { accessToken: 'yg1wdaf(해시 문자열)', vendor: 'kakao|google|naver|apple' } },
+      loginRequestDto: { value: { accessToken: 'yg1wdaf(OAuth Access Token)', vendor: 'KAKAO|GOOGLE|NAVER|APPLE' } },
     },
   })
   @ApiCreatedResponse({ description: '로그인/회원가입 성공', type: LoginResponseDto })
@@ -151,6 +151,11 @@ export class AuthController {
 
   @Post('withdraw')
   @Auth()
+  @ApiBody({
+    description: 'OAuth 액세스 토큰',
+    type: WithdrawRequestDto,
+    examples: { withdrawRequestDto: { value: { accessToken: 'yg1wdaf(OAuth Access Token)' } } },
+  })
   @ApiOperation({ description: '회원탈퇴' })
   @ApiNoContentResponse({ description: '회원탈퇴에 성공했습니다.' })
   @ApiBadRequestResponse({ description: '유효하지 않은 OAuth 요청입니다.' })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -143,10 +143,7 @@ export class AuthController {
   @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
   async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
     await this.authService.deleteRefreshToken(userId);
-    res.clearCookie('refresh_token', {
-      httpOnly: true,
-      maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
-    });
+    res.clearCookie('refresh_token');
   }
 
   @Post('withdraw')
@@ -165,9 +162,6 @@ export class AuthController {
     @Res({ passthrough: true }) res: Response,
   ): Promise<void> {
     await this.authService.withdraw(userId, withdrawRequestDto.accessToken);
-    res.clearCookie('refresh_token', {
-      httpOnly: true,
-      maxAge: +this.configService.get('JWT_REFRESH_TOKEN_EXPIRATION_TIME') * 1000,
-    });
+    res.clearCookie('refresh_token');
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -201,7 +201,7 @@ export class AuthService {
     }
   }
 
-  async deleteRefreshToken(userId: number) {
+  async deleteRefreshToken(userId: number): Promise<void> {
     try {
       await this.userRepository.update(userId, { refreshToken: null });
     } catch {
@@ -209,7 +209,7 @@ export class AuthService {
     }
   }
 
-  async withdraw(userId: number, accessToken: string) {
+  async withdraw(userId: number, accessToken: string): Promise<void> {
     try {
       const { provider } = await this.userRepository.findOne({ where: { id: userId } });
       let url: string,
@@ -236,13 +236,12 @@ export class AuthService {
           throw new BadRequestException();
         }
       }
-      const result = await axios({
+      await axios({
         url,
         method,
         headers: { Authorization: `Bearer ${accessToken}` },
       });
       await this.userRepository.softDelete(userId);
-      return result;
     } catch {
       throw new BadRequestException('유효하지 않은 OAuth 요청입니다.');
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -200,4 +200,12 @@ export class AuthService {
       throw new UnauthorizedException();
     }
   }
+
+  async deleteRefreshToken(userId: number) {
+    try {
+      await this.userRepository.update(userId, { refreshToken: null });
+    } catch {
+      throw new BadRequestException();
+    }
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -21,16 +21,16 @@ export class AuthService {
   async login(data: LoginRequestDto): Promise<TokenResponse> {
     let userId: number;
     try {
-      switch (data.vendor) {
-        case 'kakao': {
+      switch (data.provider) {
+        case AuthProvider.KAKAO: {
           userId = await this.getUserByKakaoAccessToken(data.accessToken);
           break;
         }
-        case 'naver': {
+        case AuthProvider.NAVER: {
           userId = await this.getUserByNaverAccessToken(data.accessToken);
           break;
         }
-        case 'google': {
+        case AuthProvider.GOOGLE: {
           userId = await this.getUserByGoogleAccessToken(data.accessToken);
           break;
         }

--- a/src/auth/dto/login-request.dto.ts
+++ b/src/auth/dto/login-request.dto.ts
@@ -1,11 +1,12 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsEnum, IsNotEmpty, IsString } from 'class-validator';
+import { AuthProvider } from '../../entities/types/auth-provider.enum';
 
 export class LoginRequestDto {
   @IsString()
   @IsNotEmpty()
   accessToken!: string;
 
-  @IsString()
+  @IsEnum(AuthProvider)
   @IsNotEmpty()
-  vendor!: string;
+  provider!: string;
 }

--- a/src/auth/dto/withdraw-request.dto.ts
+++ b/src/auth/dto/withdraw-request.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class WithdrawRequestDto {
+  @IsString()
+  @IsNotEmpty()
+  accessToken: string;
+}


### PR DESCRIPTION
# 작업한 내용

## 1. 로그아웃

```ts
  @Post('logout')
  @Auth()
  @ApiOperation({ description: 'refresh_token 쿠키를 삭제하고, 유저 테이블에 있는 refresh 토큰을 null로 수정합니다.' })
  @ApiNoContentResponse({ description: '로그아웃에 성공했습니다.' })
  @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
  async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
    await this.authService.deleteRefreshToken(userId);
    res.clearCookie('refresh_token');
  }
```

refresh 토큰 쿠키 값을 제거하면서, 유저 테이블에 있는 refresh 토큰 데이터도 null로 수정합니다.

### 작업 내용 사진

#### 💡 swagger 명세

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/83271772/211141663-bbc6a574-5c1d-4cd9-acc3-4fc18260a091.png">

---

#### 💡 kakao 로그아웃

<img width="456" alt="image" src="https://user-images.githubusercontent.com/83271772/211141745-17842af2-15f7-4776-b4e7-f95719d765cd.png">

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/83271772/211141815-e034edbb-046c-42d8-9dda-4fcd192b5d23.png">

<img width="929" alt="image" src="https://user-images.githubusercontent.com/83271772/211141982-7aa1e838-6aa0-4398-a436-277d1a569283.png">

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/83271772/211141862-6397bfd5-c30e-4ac1-a402-9cba25a0bd0b.png">

naver, google도 모두 테스트하여 정상 작동함을 확인했습니다.

---

### 2. 회원 탈퇴

```ts
@Post('withdraw')
  @Auth()
  @ApiBody({
    description: 'OAuth 액세스 토큰',
    type: WithdrawRequestDto,
    examples: { withdrawRequestDto: { value: { accessToken: 'yg1wdaf(OAuth Access Token)' } } },
  })
  @ApiOperation({ description: '회원탈퇴' })
  @ApiNoContentResponse({ description: '회원탈퇴에 성공했습니다.' })
  @ApiBadRequestResponse({ description: '유효하지 않은 OAuth 요청입니다.' })
  async withdraw(
    @Body() withdrawRequestDto: WithdrawRequestDto,
    @UserRequest() { userId }: UserPayload,
    @Res({ passthrough: true }) res: Response,
  ): Promise<void> {
    await this.authService.withdraw(userId, withdrawRequestDto.accessToken);
    res.clearCookie('refresh_token');
  }
```

회원탈퇴를 위해서 OAuth 토큰이 필요합니다. 이 토큰을 통해서 해당 소셜 로그인 제공 업체에 axios로 요청을 보내 정상적으로 연동을 해제합니다.

해제 이후에는 테이블에서 해당 값을 softDelete해주고, 쿠키에 있는 refresh토큰도 없애줍니다.

### 작업 내용 사진

#### 💡swagger 명세 사진

<img width="1287" alt="image" src="https://user-images.githubusercontent.com/83271772/211142037-e1adc400-a73d-4f4d-8256-3232620dc964.png">

#### 💡 kakao 회원 탈퇴

<img width="408" alt="image" src="https://user-images.githubusercontent.com/83271772/211142057-a6de3ca6-8bb5-4f65-8052-e26d60d7354c.png">

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/83271772/211142073-3613d6a0-030d-495d-a6de-948498e8a99f.png">

<img width="938" alt="image" src="https://user-images.githubusercontent.com/83271772/211142118-e33eb54f-c887-4509-9321-444fc58ee7be.png">

---

**데이터베이스**

<img width="1000" alt="image" src="https://user-images.githubusercontent.com/83271772/211142101-0ce4f7dd-0a6d-418f-9fd5-d7b6731b1a14.png">

<img width="999" alt="image" src="https://user-images.githubusercontent.com/83271772/211142137-b5cef6e8-4046-4494-94f7-6e429b8ca6ce.png">

---

**탈퇴한 상태로 재요청**

<img width="688" alt="image" src="https://user-images.githubusercontent.com/83271772/211142170-d88b47dc-0b27-4dbc-b5bf-e9e609f7f2ce.png">

# 기타

해당 스크린샷에서는 반영되지 않았는데,
swagger에서 POST는 기본적으로 201 내용이 추가되어서 @HttpCode() 데코레이터로 204만 보일 수 있도록 했습니다.

조금 더 좋은 응답코드가 있으면 수정하도록 하겠습니다.