### PR TITLE
fix, refactor: token refresh api 데코레이터 수정 및 refresh guard 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -143,13 +143,8 @@ export class AuthController {
   @ApiOperation({ description: 'refresh_token 쿠키를 삭제하고, 유저 테이블에 있는 refresh 토큰을 null로 수정합니다.' })
   @ApiNoContentResponse({ description: '로그아웃에 성공했습니다.' })
   @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
-  async logout(
-    @UserRequest() { userId }: UserPayload,
-    @Req() req: Request,
-    @Res({ passthrough: true }) res: Response,
-  ): Promise<void> {
-    const refreshToken = req.cookies['refresh_token'];
-    await this.authService.deleteRefreshToken(userId, refreshToken);
+  async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
+    await this.authService.deleteRefreshToken(userId);
     res.clearCookie('refresh_token');
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,6 +22,7 @@ import { NaverAuthGuard } from './utils/guards/naver-auth.guard';
 import { UserPayload } from './types/jwt-payload.interface';
 import { Auth } from './decorator/auth.decorator';
 import { WithdrawRequestDto } from './dto/withdraw-request.dto';
+import { RefreshGuard } from './utils/guards/jwt-refresh.guard';
 
 @ApiTags('Auth')
 @Controller('auth')
@@ -115,6 +116,7 @@ export class AuthController {
   }
 
   @Post('refresh')
+  @Auth(RefreshGuard)
   @ApiOperation({
     description: 'refresh 토큰을 사용하여 access 토큰을 재발급합니다. RTR로 refresh 토큰도 재발급합니다,',
   })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -115,9 +115,8 @@ export class AuthController {
   }
 
   @Post('refresh')
-  @Auth()
   @ApiOperation({
-    description: 'refesh 토큰을 사용하여 access 토큰을 재발급합니다. RTR로 refresh 토큰도 재발급합니다,',
+    description: 'refresh 토큰을 사용하여 access 토큰을 재발급합니다. RTR로 refresh 토큰도 재발급합니다,',
   })
   @ApiCreatedResponse({ description: 'access token 재발급 성공', type: LoginResponseDto })
   @ApiUnauthorizedResponse({ description: '유효하지 않은 refresh token으로 access token 재발급에 실패했습니다.' })
@@ -142,8 +141,13 @@ export class AuthController {
   @ApiOperation({ description: 'refresh_token 쿠키를 삭제하고, 유저 테이블에 있는 refresh 토큰을 null로 수정합니다.' })
   @ApiNoContentResponse({ description: '로그아웃에 성공했습니다.' })
   @ApiBadRequestResponse({ description: '유효하지 않은 요청입니다.' })
-  async logout(@UserRequest() { userId }: UserPayload, @Res({ passthrough: true }) res: Response): Promise<void> {
-    await this.authService.deleteRefreshToken(userId);
+  async logout(
+    @UserRequest() { userId }: UserPayload,
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    const refreshToken = req.cookies['refresh_token'];
+    await this.authService.deleteRefreshToken(userId, refreshToken);
     res.clearCookie('refresh_token');
   }
 

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { JwtStrategy } from './utils/strategies/jwt.strategy';
 import { UserModule } from '../user/user.module';
 import { GoogleStrategy } from './utils/strategies/google.strategy';
 import { NaverStrategy } from './utils/strategies/naver.strategy';
+import { RefreshStrategy } from './utils/strategies/refresh.strategy';
 
 @Module({
   imports: [
@@ -24,6 +25,6 @@ import { NaverStrategy } from './utils/strategies/naver.strategy';
     UserModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, KakaoStrategy, JwtStrategy, NaverStrategy, GoogleStrategy],
+  providers: [AuthService, KakaoStrategy, JwtStrategy, NaverStrategy, GoogleStrategy, RefreshStrategy],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,6 +9,7 @@ import axios from 'axios';
 import { TokenResponse } from './types/token-response.interface';
 import { User } from '../entities/user.entity';
 import { JwtPayload } from './types/jwt-payload.interface';
+import { JsonWebTokenError } from 'jsonwebtoken';
 
 @Injectable()
 export class AuthService {
@@ -201,10 +202,14 @@ export class AuthService {
     }
   }
 
-  async deleteRefreshToken(userId: number): Promise<void> {
+  async deleteRefreshToken(userId: number, refreshToken: string): Promise<void> {
     try {
+      await this.checkRefreshToken(refreshToken);
       await this.userRepository.update(userId, { refreshToken: null });
-    } catch {
+    } catch (err) {
+      if (err instanceof JsonWebTokenError) {
+        throw new UnauthorizedException('유효하지 않은 토큰입니다.');
+      }
       throw new BadRequestException();
     }
   }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -9,7 +9,6 @@ import axios from 'axios';
 import { TokenResponse } from './types/token-response.interface';
 import { User } from '../entities/user.entity';
 import { JwtPayload } from './types/jwt-payload.interface';
-import { JsonWebTokenError } from 'jsonwebtoken';
 
 @Injectable()
 export class AuthService {
@@ -41,7 +40,7 @@ export class AuthService {
           });
         }
       }
-    } catch (error) {
+    } catch {
       throw new BadRequestException({
         message: '유효하지 않는 OAuth 요청입니다.',
       });
@@ -202,14 +201,10 @@ export class AuthService {
     }
   }
 
-  async deleteRefreshToken(userId: number, refreshToken: string): Promise<void> {
+  async deleteRefreshToken(userId: number): Promise<void> {
     try {
-      await this.checkRefreshToken(refreshToken);
       await this.userRepository.update(userId, { refreshToken: null });
-    } catch (err) {
-      if (err instanceof JsonWebTokenError) {
-        throw new UnauthorizedException('유효하지 않은 토큰입니다.');
-      }
+    } catch {
       throw new BadRequestException();
     }
   }

--- a/src/auth/decorator/auth.decorator.ts
+++ b/src/auth/decorator/auth.decorator.ts
@@ -2,6 +2,6 @@ import { applyDecorators, UseGuards } from '@nestjs/common';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from '../utils/guards/jwt-auth.guard';
 
-export function Auth() {
-  return applyDecorators(UseGuards(JwtAuthGuard), ApiBearerAuth('access-token'));
+export function Auth(guard = JwtAuthGuard) {
+  return applyDecorators(UseGuards(guard), ApiBearerAuth('access-token'));
 }

--- a/src/auth/dto/jwt-payload.dto.ts
+++ b/src/auth/dto/jwt-payload.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsNumber } from 'class-validator';
 
-export class jwtPayload {
+export class JwtPayload {
   @IsNumber()
   @IsNotEmpty()
   id: number;

--- a/src/auth/dto/jwt-payload.dto.ts
+++ b/src/auth/dto/jwt-payload.dto.ts
@@ -1,7 +1,0 @@
-import { IsNotEmpty, IsNumber } from 'class-validator';
-
-export class JwtPayload {
-  @IsNumber()
-  @IsNotEmpty()
-  id: number;
-}

--- a/src/auth/utils/guards/jwt-auth.guard.ts
+++ b/src/auth/utils/guards/jwt-auth.guard.ts
@@ -1,5 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { TokenExpiredError } from 'jsonwebtoken';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor() {
+    super();
+  }
+
+  handleRequest(err: any, user: any, info: any, context: ExecutionContext, status?: any) {
+    if (info instanceof TokenExpiredError) {
+      throw new UnauthorizedException('만료된 access 토큰입니다.');
+    }
+    if (!user) {
+      throw new UnauthorizedException('적절하지 않은 요청입니다.');
+    }
+    return user;
+  }
+}

--- a/src/auth/utils/guards/jwt-refresh.guard.ts
+++ b/src/auth/utils/guards/jwt-refresh.guard.ts
@@ -1,0 +1,20 @@
+import { ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { TokenExpiredError } from 'jsonwebtoken';
+
+@Injectable()
+export class RefreshGuard extends AuthGuard('refresh') {
+  constructor() {
+    super();
+  }
+
+  handleRequest(err: any, user: any, info: any, context: ExecutionContext, status?: any) {
+    if (info instanceof TokenExpiredError) {
+      throw new UnauthorizedException('만료된 refresh 토큰입니다.');
+    }
+    if (!user) {
+      throw new UnauthorizedException('적절하지 않은 요청입니다.');
+    }
+    return user;
+  }
+}

--- a/src/auth/utils/strategies/jwt.strategy.ts
+++ b/src/auth/utils/strategies/jwt.strategy.ts
@@ -2,9 +2,8 @@ import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { UserPayload } from 'src/auth/types/jwt-payload.interface';
+import { JwtPayload, UserPayload } from 'src/auth/types/jwt-payload.interface';
 import { AuthService } from '../../auth.service';
-import { JwtPayload } from '../../dto/jwt-payload.dto';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {

--- a/src/auth/utils/strategies/jwt.strategy.ts
+++ b/src/auth/utils/strategies/jwt.strategy.ts
@@ -4,7 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { UserPayload } from 'src/auth/types/jwt-payload.interface';
 import { AuthService } from '../../auth.service';
-import { jwtPayload } from '../../dto/jwt-payload.dto';
+import { JwtPayload } from '../../dto/jwt-payload.dto';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
@@ -16,9 +16,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate(payload: jwtPayload): Promise<UserPayload> {
-    try {
-      await this.authService.validateJwt(payload.id);
+  async validate(payload: JwtPayload): Promise<UserPayload> {
       return { userId: payload.id };
     } catch (err) {
       throw new UnauthorizedException();

--- a/src/auth/utils/strategies/jwt.strategy.ts
+++ b/src/auth/utils/strategies/jwt.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
@@ -17,9 +17,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: JwtPayload): Promise<UserPayload> {
-      return { userId: payload.id };
-    } catch (err) {
-      throw new UnauthorizedException();
-    }
+    return { userId: payload.id };
   }
 }

--- a/src/auth/utils/strategies/refresh.strategy.ts
+++ b/src/auth/utils/strategies/refresh.strategy.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PassportStrategy } from '@nestjs/passport';
+import { Request } from 'express';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+import { AuthService } from '../../auth.service';
+import { JwtPayload } from '../../dto/jwt-payload.dto';
+import { UserPayload } from '../../types/jwt-payload.interface';
+
+@Injectable()
+export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
+  constructor(private readonly configService: ConfigService, private readonly authService: AuthService) {
+    super({
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request: Request) => {
+          return request?.cookies?.refresh_token;
+        },
+      ]),
+      ignoreExpiration: false,
+      secretOrKey: configService.get<string>('JWT_REFRESH_TOKEN_SECRET'),
+    });
+  }
+
+  async validate(payload: JwtPayload): Promise<UserPayload> {
+    return { userId: payload.id };
+  }
+}

--- a/src/auth/utils/strategies/refresh.strategy.ts
+++ b/src/auth/utils/strategies/refresh.strategy.ts
@@ -4,8 +4,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { Request } from 'express';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { AuthService } from '../../auth.service';
-import { JwtPayload } from '../../dto/jwt-payload.dto';
-import { UserPayload } from '../../types/jwt-payload.interface';
+import { JwtPayload, UserPayload } from '../../types/jwt-payload.interface';
 
 @Injectable()
 export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {


### PR DESCRIPTION
# 작업한 내용

1. token 재발급 api에서 @auth() 데코레이터를 사용하기 때문에 만료되면 요청이 안 보내질 수 있는 거 발견해서 수정했습니다.

2. 추가로 userId가 필요했어서 refresh 가드를 생성해뒀습니다.

3. 프론트에서 계속 401 에러 얘기하셔서 혼동되시지 않도록 가드에서 처리한 후에 메시지(만료 및 적절하지 않은 토큰임)를 추가했습니다.

데브랭크 보면서 많이 참고했습니다,,